### PR TITLE
Updated the VSTS Field Mapping to use the Unlocked Package Namespace …

### DIFF
--- a/VSTS_Default_Field_Mapping.csv
+++ b/VSTS_Default_Field_Mapping.csv
@@ -3,7 +3,7 @@ Project__c,Salesforce_Field_Name__c,Third_Party_Field_Name__c,Target_Field_Type_
 <INSERT_PROJECT_ID>,copado__Project__c,projectId,,FALSE,TRUE
 <INSERT_PROJECT_ID>,copado__User_Story_Title__c,System.Title,,FALSE,FALSE
 <INSERT_PROJECT_ID>,recordTypeId,recordTypeId,,FALSE,TRUE
-<INSERT_PROJECT_ID>,External_Id__c,id,,FALSE,FALSE
+<INSERT_PROJECT_ID>,copadoccmint__External_Id__c,id,,FALSE,FALSE
 <INSERT_PROJECT_ID>,copado__Developer__c,developer,,FALSE,TRUE
 <INSERT_PROJECT_ID>,copado__Story_Points_SFDC__c,Microsoft.VSTS.Scheduling.StoryPoints,,FALSE,FALSE
 <INSERT_PROJECT_ID>,copado__Status__c,System.State,,FALSE,FALSE


### PR DESCRIPTION
…for External ID

This PR resolves Issue #9 
By appending the namespace _copadoccmint_ to the External_ID__c field the issue gets resolved and sync. of stories from ADO (Formerly known as VSTS) is completed successfully.